### PR TITLE
stop string from parsing any further options

### DIFF
--- a/functions/mm.fish
+++ b/functions/mm.fish
@@ -134,9 +134,9 @@ function mm --description "MakeMeFish - List all Make targets in the Makefile of
             end
             # Interactive?
             if test -n "$interactive"; and test $interactive -eq 1   
-                string join0 $targets | eval (__mm_fzf_command $filename 1 $make_command $initial_query)
+                string join0 -- $targets | eval (__mm_fzf_command $filename 1 $make_command $initial_query)
             else
-                string join0 $targets | eval (__mm_fzf_command $filename 0 $make_command $initial_query) | read -lz result  # print targets as a list, pipe them to fzf, put the chosen command in $result
+                string join0 -- $targets | eval (__mm_fzf_command $filename 0 $make_command $initial_query) | read -lz result  # print targets as a list, pipe them to fzf, put the chosen command in $result
                 set result (string trim -- $result)  # Trim newlines and whitespace from the command
                 and commandline -- "$make_command $result"  # Prepend the make command
                 commandline -f repaint  # Repaint command line


### PR DESCRIPTION
This PR added `--` to stop string from parsing any option-like flag in the target.

I encountered the following error:
```sh
string join0: Unknown option “-sL”

~/.config/fish/functions/mm.fish (line 139): 
                string join0 $targets | eval (__mm_fzf_command $filename 0 $make_command $initial_query) | read -lz result  # print targets as a list, pipe them to fzf, put the chosen command in $result
                ^
in function 'mm'
```
which was because in `$targets`, there are some option-like string (i.e. in the MakeFile, there are the `-sL` flag that `mm.fish` is complaining about)

The `--` will stops `string` from parsing any possible options within the string.