### PR TITLE
fix backslashed line

### DIFF
--- a/functions/mm.fish
+++ b/functions/mm.fish
@@ -54,8 +54,10 @@ function mm --description "MakeMeFish - List all Make targets in the Makefile of
 
         set makeflags -f $filename
         
+        # first awk merges any line that ends with a backslash with the next line
         if make --version 2>/dev/null | string match -q 'GNU*'
             make $makeflags -pRrq : 2>/dev/null |
+            awk '{if (sub(/\\\$/,"")) printf "%s", $0; else print $0}' |
             awk -F: '/^# Files/,/^# Finished Make data base/ {
                         if ($1 == "# Not a target") skip = 1;
                         if ($1 !~ "^[#.\t]") { 


### PR DESCRIPTION
The current implementation does not handles backslashed command, and treat them as target.

See the following example of a `Makefile`:
```
all: test1 test2 test3 test4    
    
test1:    
  echo foo bar    
    
test2:    
  echo foo \    
  bar    
    
test3:    
  echo foo \    
    bar    
    
test4:    
  echo foo \    
bar1 \    
    bar2 \    
  bar3 \    
bar4 \
```

It is common to have backslash on long command (e.g. test2, though test4 is very extreme as a test case), but they are all valid Makefile target:
```sh
$ make -s
foo bar
foo bar
foo bar
foo bar1 bar2 bar3 bar4
```

-----------------

Without the PR:
```sh
$ make -pRrq | awk -F: '/^# Files/,/^# Finished Make data base/ {    
                if ($1 == "# Not a target") skip = 1;    
                if ($1 !~ "^[#.\t]") {     
                    if (!skip) print $1; skip=0                                             
                }    
            }'


test4
bar1 \
    bar2 \
  bar3 \
bar4 \


all

test3
    bar

test2
  bar

test1





```

![1](https://user-images.githubusercontent.com/22362177/85218011-95c1c280-b3d9-11ea-915b-67d182fdc0c8.png)

With the PR:
```sh
$ make -pRrq | awk '{if (sub(/\\\$/,"")) printf "%s", $0; else print $0}' |
             awk -F: '/^# Files/,/^# Finished Make data base/ {    
                 if ($1 == "# Not a target") skip = 1;    
                 if ($1 !~ "^[#.\t]") {     
                     if (!skip) print $1; skip=0                                             
                 }    
             }'


test4

all

test3

test2

test1





```

![2](https://user-images.githubusercontent.com/22362177/85218017-9bb7a380-b3d9-11ea-95cc-825df61b57a4.png)
